### PR TITLE
Create new tag when version in Chart.yaml is bumped

### DIFF
--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -1,0 +1,27 @@
+name: Create Tag for Release
+
+on:
+  push:
+    branches:
+    - 'master'
+    paths:
+     - 'chart/k8gb/Chart.yaml'
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get tag
+        id: get_tag
+        run: |
+          new_tag=$(cat chart/k8gb/Chart.yaml | awk '/appVersion:/ {print $2}')
+          echo "::set-output name=new_tag::${new_tag}"
+      - name: Push Tag
+        uses: mathieudutour/github-tag-action@v5.6
+        if: "contains(github.event.head_commit.message, 'RELEASE:')"
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true
+          tag_prefix: ""
+          custom_tag: ${{ steps.get_tag.outputs.new_tag }}


### PR DESCRIPTION
The commit message has to contain '[release]' to trigger this action.
The version is taken from the appVersion field from Chart.yaml

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>