### PR TITLE
Let renovate update the k3d manifests

### DIFF
--- a/k3d/gslb.yaml.tmpl
+++ b/k3d/gslb.yaml.tmpl
@@ -2,6 +2,8 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb$CLUSTER_INDEX
+# Used by renovate
+# repo: k3s-io/k3s
 image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -2,6 +2,8 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb1
+# Used by renovate
+# repo: k3s-io/k3s
 image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -2,6 +2,8 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb2
+# Used by renovate
+# repo: k3s-io/k3s
 image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -2,6 +2,8 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb3
+# Used by renovate
+# repo: k3s-io/k3s
 image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network

--- a/renovate.json5
+++ b/renovate.json5
@@ -87,5 +87,14 @@
       ],
       "autoReplaceStringTemplate": "  - sbom-file: https://github.com/{{{depName}}}/releases/download/v{{{newValue}}}/k8gb_{{{newValue}}}_linux_amd64.tar.gz.sbom.json"
     },
+    // update the files in k3d/ with the up-to-date k8s version
+    {
+      "fileMatch": ["^k3d/.*y[a]?ml.*$"],
+      "datasourceTemplate": "github-releases",
+      "matchStrings": [
+        "repo: (?<depName>.*)\n(\\s*)image: \"?.+:(?<currentValue>.*?)\"?\n",
+      ],
+      "extractVersionTemplate": "^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<compatibility>\\+k3s)(?<build>\\d+)$",
+    },
   ],
 }


### PR DESCRIPTION
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
